### PR TITLE
Fix whitespace in popup message

### DIFF
--- a/git-messenger.el
+++ b/git-messenger.el
@@ -55,7 +55,7 @@
       (unless (zerop (call-process-shell-command cmd nil t))
         (error "Failed: %s" cmd))
       (goto-char (point-min))
-      (forward-line 4)
+      (forward-paragraph)
       (buffer-substring-no-properties (point) (point-max)))))
 
 ;;;###autoload


### PR DESCRIPTION
## 概要

ポップアップメッセージの上部の余白が異なる問題を修正しました．
## 原因

`$ git cat-file commit` の表示で，parent がある場合とない場合で行数が異なっているため，一行分余白がずれる場合がありました．
### 例

```
tree 3cccc2fcb2b9a64790ddbb20d4e0b7f496e305df
author Syohei YOSHIDA <syohex@gmail.com> 1368692173 +0900
committer Syohei YOSHIDA <syohex@gmail.com> 1368692173 +0900

init repos
```

```
tree 4ab6db7e8d4408c8aa70f6e809b6bbb55e27d7e5
parent de3096daeed4ac950851af441185b7b9d0653b9c
author Keisuke Tada <tdkskdt@gmail.com> 1369730656 +0900
committer Keisuke Tada <tdkskdt@gmail.com> 1369730656 +0900

Fix whitespace in popup message
```
## 対策

parent のあるなしによらず余白を同じにするために，`forward-line` を使うのをやめ， `forward-paragraph` を用いることで解決しました．
## Screenshots
### Before

![before.png](https://qiita-image-store.s3.amazonaws.com/0/17841/f4dafd5a-590d-fb88-f087-14e160859861.png)
### After

![after.png](https://qiita-image-store.s3.amazonaws.com/0/17841/2eca37b9-8857-d270-f820-a181d6910119.png)
