### PR TITLE
Change type of git-messenger:show-detail from bool to boolean.

### DIFF
--- a/git-messenger.el
+++ b/git-messenger.el
@@ -41,7 +41,7 @@
 
 (defcustom git-messenger:show-detail nil
   "Pop up commit ID and author name too"
-  :type 'bool
+  :type 'boolean
   :group 'git-messenger)
 
 (defcustom git-messenger:before-popup-hook nil


### PR DESCRIPTION
This change allows customization of the `git-messenger:show-detail` variable.

As it stands, one gets the following message when trying `M-x customize-variable git-messenger:show-detail`:

```
Creating customization items...
widget-apply: Symbol's function definition is void: nil
```
