### PR TITLE
Improve detecting current VCS type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: generic
+sudo: false
+before_install:
+  - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh
+  - evm install $EVM_EMACS --use --skip
+  - cask
+env:
+  - EVM_EMACS=emacs-24.3-travis
+  - EVM_EMACS=emacs-24.4-travis
+  - EVM_EMACS=emacs-24.5-travis
+script:
+  - emacs --version
+  - make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY : test
+
+EMACS ?= emacs
+CASK ?= cask
+
+LOADPATH = -L .
+
+ELPA_DIR = $(shell EMACS=$(EMACS) $(CASK) package-directory)
+
+test: elpa
+	$(CASK) exec $(EMACS) -Q -batch $(LOADPATH) \
+		-l test/test.el \
+		-f ert-run-tests-batch-and-exit
+
+elpa: $(ELPA_DIR)
+$(ELPA_DIR): Cask
+	$(CASK) install
+	touch $@

--- a/git-messenger.el
+++ b/git-messenger.el
@@ -309,10 +309,14 @@ and menus.")
   "Key mappings of git-messenger. This is enabled when commit message is popup-ed.")
 
 (defun git-messenger:find-vcs ()
-  (cl-loop for vcs in git-messenger:handled-backends
-           for dir = (assoc-default vcs git-messenger:directory-of-vcs)
-           when (locate-dominating-file default-directory dir)
-           return vcs))
+  (let ((longest 0)
+        result)
+    (dolist (vcs git-messenger:handled-backends result)
+      (let* ((dir (assoc-default vcs git-messenger:directory-of-vcs))
+             (vcs-root (locate-dominating-file default-directory dir)))
+        (when (and vcs-root (> (length vcs-root) longest))
+          (setq longest (length vcs-root)
+                result vcs))))))
 
 (defun git-messenger:svn-message (msg)
   (with-temp-buffer

--- a/test/test.el
+++ b/test/test.el
@@ -1,0 +1,41 @@
+;;; test.el --- test of git-messenger
+
+;; Copyright (C) 2016 by Syohei YOSHIDA
+
+;; Author: Syohei YOSHIDA <syohex@gmail.com>
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Code:
+
+(require 'ert)
+(require 'git-messenger)
+
+(ert-deftest find-vcs ()
+  ""
+  (let* ((tmp-dir (file-name-as-directory
+                   (concat default-directory (make-temp-name "git-messenger"))))
+         (git-dir (concat tmp-dir ".git"))
+         (hg-dir (concat tmp-dir "foo/" ".hg"))
+         (test-dir (concat tmp-dir "foo/bar/")))
+    (unwind-protect
+        (progn
+          (make-directory git-dir t)
+          (make-directory hg-dir t)
+          (make-directory test-dir t)
+          (let ((default-directory test-dir))
+            (should (eq (git-messenger:find-vcs) 'hg))))
+      (delete-directory tmp-dir t))))
+
+;;; test.el ends here


### PR DESCRIPTION
Original code returns wrong result following case
 - current directory is foo/bar/baz
 - foo is controlled by git
 - foo/bar is controlled by subversion
Then git is returned in original code.

New version checks all VCS directory and use longest path VCS type.